### PR TITLE
Represent 500 Internal Server Error with 'Fire'

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -72,7 +72,7 @@
 
 | Status Code   | Message                         | Emoji |
 | ------------- | -------------                   | ----- |
-| 500           | Internal Server Error           |       |
+| 500           | Internal Server Error           |  🔥   |
 | 501           | Not Implemented                 |  🚧   |
 | 502           | Bad Gateway                     |       |
 | 503           | Service Unavailable             |       |


### PR DESCRIPTION
The status 500 Internal Server Error is defined as _"The server encountered an unexpected condition which prevented it from fulfilling the request"_. In practice this usually results from the server application crashing, which is often represented with fire, see for example the [Halt and Catch Fire instruction](https://en.wikipedia.org/wiki/Halt_and_Catch_Fire).

500 Internal Server Error is also used as a catch-all for many other server-side faults and thus needs an emoji which is generic enough to cover a wide range of errors.

Proposed emoji: :fire: 'FIRE' (U+1F525)
