### PR TITLE
Add (U+2694) CROSSED SWORDS for 409 Conflict

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -49,7 +49,7 @@
 | 406           | Not Acceptable                  |   🍋  |
 | 407           | Proxy Authentication Required   |       |
 | 408           | Request Timeout                 |   💤  |
-| 409           | Conflict                        |       |
+| 409           | Conflict                        |  ⚔️   |
 | 410           | Gone                            |  💨   |
 | 411           | Length Required                 |       |
 | 412           | Precondition Failed             |       |


### PR DESCRIPTION
Unicode chars also contain a gun, a sword and a crossbow as weapons. However all of these items are represented as singulars. 

Conflict can be defined as: to fight or contend; do battle.

`CROSSED SWORDS` is the closest we can do.
